### PR TITLE
GitHub verilator

### DIFF
--- a/.github/workflows/verilator.yml
+++ b/.github/workflows/verilator.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
-    branches: [ "main" "github-verilator" ]
+    branches: [ "main", "github-verilator" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/verilator.yml
+++ b/.github/workflows/verilator.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Verilator
-        uses: awalsh128/cache-apt-pkgs-action@latest
+      - name: Setup Arch Linux environment with Verilator
+        uses: RangHo/setup-arch@v1.2.0
         with:
-          packages: verilator
-          version: 1.0
+          packages: "verilator gcc"
 
       - name: Run helloworld in systemverilog
         run: |
           verilator --version
           verilator --sv --binary -j 0 -Wall helloworld.v
           ./obj-dir/Vhelloworld
+        shell: arch.sh {0}

--- a/.github/workflows/verilator.yml
+++ b/.github/workflows/verilator.yml
@@ -23,5 +23,6 @@ jobs:
 
       - name: Run helloworld in systemverilog
         run: |
+          verilator --version
           verilator --sv --binary -j 0 -Wall helloworld.v
           ./obj-dir/Vhelloworld

--- a/.github/workflows/verilator.yml
+++ b/.github/workflows/verilator.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
-    branches: [ "main", "github-verilator" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/verilator.yml
+++ b/.github/workflows/verilator.yml
@@ -24,5 +24,5 @@ jobs:
         run: |
           verilator --version
           verilator --sv --binary -j 0 -Wall helloworld.v
-          ${{ github.workspace }}/obj-dir/Vhelloworld
+          ${{ github.workspace }}/obj_dir/Vhelloworld
         shell: arch.sh {0}

--- a/.github/workflows/verilator.yml
+++ b/.github/workflows/verilator.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Arch Linux environment with Verilator
         uses: RangHo/setup-arch@v1.2.0
         with:
-          packages: "verilator gcc"
+          packages: "verilator python"
 
       - name: Run helloworld in systemverilog
         run: |

--- a/.github/workflows/verilator.yml
+++ b/.github/workflows/verilator.yml
@@ -1,8 +1,5 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
@@ -13,14 +10,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v4
       - name: Install Verilator

--- a/.github/workflows/verilator.yml
+++ b/.github/workflows/verilator.yml
@@ -22,7 +22,6 @@ jobs:
 
       - name: Run helloworld in systemverilog
         run: |
-          verilator --version
           verilator --sv --binary -j 0 -Wall helloworld.v
           ${{ github.workspace }}/obj_dir/Vhelloworld
         shell: arch.sh {0}

--- a/.github/workflows/verilator.yml
+++ b/.github/workflows/verilator.yml
@@ -24,5 +24,5 @@ jobs:
         run: |
           verilator --version
           verilator --sv --binary -j 0 -Wall helloworld.v
-          ./obj-dir/Vhelloworld
+          ${{ github.workspace }}/obj-dir/Vhelloworld
         shell: arch.sh {0}

--- a/.github/workflows/verilator.yml
+++ b/.github/workflows/verilator.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
-    branches: [ "main" ]
+    branches: [ "main" "github-verilator" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
`ubuntu-latest` uses a verilator version from 2020. Use arch linux instead to have a more recent verilator.